### PR TITLE
A couple of small fixes

### DIFF
--- a/xo-install.sh
+++ b/xo-install.sh
@@ -170,7 +170,7 @@ function InstallXO {
 	sed -i "s#ExecStart=.*#ExecStart=$INSTALLDIR\/xo-server\/bin\/xo-server#" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/xo-server.service
 	echo
 	echo "Adding WorkingDirectory parameter to systemd service configuration"
-	sed -i "/ExecStart=.*/a WorkingDirectory=/etc/xo/xo-server" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/xo-server.service
+	sed -i "/ExecStart=.*/a WorkingDirectory=$INSTALLDIR/xo-server" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/xo-server.service
 
 	if [ $XOUSER ]; then
 		echo "Adding user to systemd config"

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -14,7 +14,7 @@ function CheckUser {
 
 	# Make sure the script is ran as root
 
-	if [[ ! $(whoami) == "root" ]]; then
+	if [[ ! "$(id -u)" == "0" ]]; then
 		echo "This script needs to be ran as root"
 		exit 0
 	fi


### PR DESCRIPTION
PR addresses a couple of issues.

1. Using `id -u` is preferable to using `whoami` for detecting root. The root user doesn't have to be named root but must be uid 0.
2. Use $INSTALLDIR/xo-server for working directory in systemd service file. 