### PR TITLE
Add setcap installation to Debian

### DIFF
--- a/xo-install.sh
+++ b/xo-install.sh
@@ -140,6 +140,14 @@ function InstallDependenciesDebian {
 		echo "done"
 	fi
 
+	# install setcap for non-root port binding if missing
+	if [[ -z $(which setcap) ]]; then
+		echo
+		echo -n "Installing setcap..."
+		apt-get install -y libcap2-bin >/dev/null
+		echo "done"
+	fi
+
 	# only install yarn repo and package if not found
 	if [[ -z $(dpkg -l | grep yarn) ]]; then
 		echo


### PR DESCRIPTION
This commit adds the installation for `libcap2-bin` for Debian systems.

Issue #8 references the issue of `setcap` not existing in Debian by default, and commit 618aeed adds a note that the `libcap2-bin` will be installed, but that commit doesn't add the code to perform the installation.