### PR TITLE
Add config file, easy HTTPS setup, faster upgrades, and tagged release upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 xo-install.log
+xo-install.cfg
 tests/*/*
 tests/*
 !tests/Ubuntu

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Tool has been tested to work with following distros:
 In order to use file level restore from delta backups, the service needs to be ran as root.
 CentOS installation is currently not able to do file level restore if the backed up disk contains LVM.
 
-CentOS setup is confirmed to work with fresh minimal installation and SELinux enabled. 
+CentOS setup is confirmed to work with fresh minimal installation and SELinux enabled.
 Although script doesn't do any SELinux checks or modifications, so you need to take care of possible changes by yourself according to your system.
 
 Tool makes all necessary changes required for Xen-Orchestra to run (including packages, user creation, permissions). Please evaluate script if needed.

--- a/docker/monit-services
+++ b/docker/monit-services
@@ -10,5 +10,5 @@ check process redis with pidfile /var/run/redis_6379.pid
 	stop program = "/usr/bin/redis-cli shutdown"
 
 check process rpcbind
-    matching "rpcbind"
-    start program = "/usr/sbin/rpcbind"
+	matching "rpcbind"
+	start program = "/usr/sbin/rpcbind"

--- a/sample.xo-install.cfg
+++ b/sample.xo-install.cfg
@@ -7,7 +7,8 @@ PORT="80"
 # Base dir for installation and future updates
 INSTALLDIR="/etc/xo"
 
-# Git branch or tag (append tags/ before the tag name) where xen-orchestra sources are fetched
+# Git branch or tag (append tags/ before the tag name) where xen-orchestra sources are fetched.
+# Also, you can set this to "release" to use the latest tagged branch.
 BRANCH="master"
 
 # Log path for possible errors

--- a/sample.xo-install.cfg
+++ b/sample.xo-install.cfg
@@ -21,3 +21,7 @@ AUTOUPDATE="true"
 
 # Define the number of previous installations you want to keep. Needs to be at least 1
 PRESERVE="3"
+
+# X.509 certificate setup.
+PATH_TO_HTTPS_CERT=
+PATH_TO_HTTPS_KEY=

--- a/sample.xo-install.cfg
+++ b/sample.xo-install.cfg
@@ -1,0 +1,23 @@
+# Optional user that runs the service. root by default
+#XOUSER="node"
+
+# Port number where xen-orchestra service is bound
+PORT="80"
+
+# Base dir for installation and future updates
+INSTALLDIR="/etc/xo"
+
+# Git branch or tag (append tags/ before the tag name) where xen-orchestra sources are fetched
+BRANCH="master"
+
+# Log path for possible errors
+LOGFILE="$(dirname $0)/xo-install.log"
+
+# comma separated list of plugins to be installed, check README for more information
+#PLUGINS="xo-server-transport-email,xo-server-usage-report,xo-server-perf-alert"
+
+# NodeJS and Yarn are automatically updated when running update. Switch this option to false if you want to disable it.
+AUTOUPDATE="true"
+
+# Define the number of previous installations you want to keep. Needs to be at least 1
+PRESERVE="3"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -18,24 +18,24 @@ function RunTestsSingle {
 	curl -s -L 192.168.33.101 >> $LOGFILE 2>&1 || false
 
 	if [[ $? == "1" ]]; then
-	echo "$1 install HTTP Check: failed"
+		echo "$1 install HTTP Check: failed"
 	else
 		echo "$1 install HTTP Check: success"
 	fi
 	sleep 5
 
 	vagrant provision --provision-with update >> $LOGFILE 2>&1
-        sleep 5
-        echo "" >> $LOGFILE
-        echo "Curl output after update:" >> $LOGFILE
-        curl -s -L 192.168.33.101 >> $LOGFILE 2>&1 || false
+	sleep 5
+	echo "" >> $LOGFILE
+	echo "Curl output after update:" >> $LOGFILE
+	curl -s -L 192.168.33.101 >> $LOGFILE 2>&1 || false
 
-        if [[ $? == "1" ]]; then
-        echo "$1 update HTTP Check: failed"
-        else
-                echo "$1 update HTTP Check: success"
-        fi
-        sleep 5
+	if [[ $? == "1" ]]; then
+		echo "$1 update HTTP Check: failed"
+	else
+		echo "$1 update HTTP Check: success"
+	fi
+	sleep 5
 
 	vagrant destroy -f >> $LOGFILE 2>&1
 	unset VAGRANT_CWD
@@ -54,13 +54,13 @@ for x in CentOS Debian Ubuntu; do
 		echo "Vagrant box failed to start, exiting"
 		exit 1;
 	fi
-	
+
 	vagrant provision --provision-with install >> $LOGFILE 2>&1
 	sleep 5
 	echo "" >> $LOGFILE
 	echo "Curl output after install:" >> $LOGFILE
 	curl -s -L -m 5 192.168.33.101 >> $LOGFILE 2>&1 || false
-	
+
 	if [[ $? == "1" ]]; then
 		echo "$x install HTTP Check: failed"
 	else

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -120,7 +120,7 @@ function InstallDependenciesDebian {
 	trap ErrorHandling ERR INT
 
 	# Install necessary dependencies for XO build
-        
+
 	echo
 	echo -n "Running apt-get update..."
 	apt-get update >/dev/null
@@ -178,8 +178,8 @@ function InstallDependenciesDebian {
 	echo "Enabling and starting redis service"
 	/bin/systemctl enable redis-server >/dev/null && /bin/systemctl start redis-server >/dev/null
 
-        echo "Enabling and starting rpcbind service"
-        /bin/systemctl enable rpcbind >/dev/null && /bin/systemctl start rpcbind >/dev/null
+	echo "Enabling and starting rpcbind service"
+	/bin/systemctl enable rpcbind >/dev/null && /bin/systemctl start rpcbind >/dev/null
 
 } 2>$LOGFILE
 
@@ -203,9 +203,9 @@ function UpdateNodeYarn {
 function InstallXOPlugins {
 
 	set -e
-	
+
 	trap ErrorHandling ERR INT
-	
+
 	if [[ "$PLUGINS" ]] && [[ ! -z "$PLUGINS" ]]; then
 
 		echo
@@ -436,9 +436,9 @@ function HandleArgs {
 			;;
 		esac
 
-}	
+}
 
-function RollBackInstallation {	
+function RollBackInstallation {
 
 	INSTALLATIONS=($(find $INSTALLDIR/xo-builds/ -maxdepth 1 -type d -name "xen-orchestra-*"))
 
@@ -643,7 +643,7 @@ read -p ": " option
 					;;
 					2)
 						PullDockerImage
-						
+
 					;;
 					3)
 						exit 0

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -6,33 +6,16 @@
 # Repository: https://github.com/ronivay/XenOrchestraInstallerUpdater   #
 #########################################################################
 
-### Start of editable variables ###
+SAMPLE_CONFIG_FILE="sample.xo-install.cfg"
+CONFIG_FILE="xo-install.cfg"
 
-# Optional user that runs the service. root by default
-#XOUSER="node"
+# Deploy default configuration file if the user doesn't have their own yet.
+if [[ ! -e "$CONFIG_FILE" ]]; then
+	cp $SAMPLE_CONFIG_FILE $CONFIG_FILE
+fi
 
-# Port number where xen-orchestra service is bound
-PORT="80"
-
-# Base dir for installation and future updates
-INSTALLDIR="/etc/xo"
-
-# Git branch or tag (append tags/ before the tag name) where xen-orchestra sources are fetched
-BRANCH="master"
-
-# Log path for possible errors
-LOGFILE="$(dirname $0)/xo-install.log"
-
-# comma separated list of plugins to be installed, check README for more information
-#PLUGINS="xo-server-transport-email,xo-server-usage-report,xo-server-perf-alert"
-
-# NodeJS and Yarn are automatically updated when running update. Switch this option to false if you want to disable it.
-AUTOUPDATE="true"
-
-# Define the number of previous installations you want to keep. Needs to be at least 1
-PRESERVE="3"
-
-### End of editable variables ###
+# See this file for all script configuration variables.
+source $CONFIG_FILE
 
 function CheckUser {
 

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -266,7 +266,16 @@ function InstallXO {
 	rm -rf "$INSTALLDIR/xo-builds/xen-orchestra-$TIME"
 	cp -r "$XO_SRC_DIR" "$INSTALLDIR/xo-builds/xen-orchestra-$TIME"
 
-	if [[ "$BRANCH" != "master" ]]; then
+	if [[ "$BRANCH" == "release" ]]; then
+		cd $INSTALLDIR/xo-builds/xen-orchestra-$TIME
+		TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+
+		echo
+		echo "Checking out latest tagged release '$TAG'"
+
+		git checkout $TAG 2> /dev/null  # Suppress the detached-head message.
+		cd $(dirname $0)
+	elif [[ "$BRANCH" != "master" ]]; then
 		echo
 		echo "Checking out source code from branch '$BRANCH'"
 


### PR DESCRIPTION
I realize this is quite a few features bundled into one PR, so let me know if you want me to break this up into a few PRs. Each feature is a separate commit though, so it should be easy to do things one-at-a-time.

# Config File

[Commit for this feature.](https://github.com/ronivay/XenOrchestraInstallerUpdater/commit/3944e5dabf4d437437f2e31c8cb45fb0ad45f86d)

Right now, if users want to make changes to the default configuration, they must edit `xo-install.sh`. This means that before they pull updates to this repo, they have to stash their changes or commit them and then deal with merges.

This commit removes all of the user-configurable options from `xo-install.sh` and instead sources them from a config file that is not tracked by git (`xo-install.cg`). When a user doesn't have this file (likely the case when they first run this), the installer will make a new copy for them based on ` sample.xo-install.cfg`. Whenever we want to add new configurable options, we can just add them to this file, which the user presumably won't touch, and they can then manually add any new features to their own private `xo-install.cfg`.

# HTTPS Setup

[Commit for this feature.](https://github.com/ronivay/XenOrchestraInstallerUpdater/commit/d02296fe570929c78894124390b6212b8f77a59b)

This is also mentioned in [this issue](https://github.com/ronivay/XenOrchestraInstallerUpdater/issues/12).

This just adds easy options for users to serve the web server over HTTPS using certificates of their choosing. By default, this is disabled, and the web server will run over HTTP.

# Faster Upgrades

[Commit for this feature.](https://github.com/ronivay/XenOrchestraInstallerUpdater/commit/2ede089207635646d6a15f89eb6290cf054208aa)

This does 2 things to speed up Xen Orchestra upgrades:

1. Instead of cloning a new xen-orchestra git repo on every upgrade, create a dedicated source tree folder (located at `$INSTALLDIR/xo-src/xen-orchestra`) which is used to pull in all git updates. Whenever an installation/update happens, this folder will just be copied to `$INSTALLDIR/xo-builds/xen-orchestra-$TIME`. Right now, the xen-orchestra source tree is about 44 MB, so cloning it on every update takes a bit of time, especially on slower internet connections. The downside here is that we have this extra source tree sitting around on your HD taking up space, but considering a compiled source tree takes up 10 times the space of the raw source tree, I imagine this isn't a huge deal.
2. Don't run the `yarn` build if the currently-installed `xo-server`/`xo-web` source tree is identical to the source tree we plan on installing. This runs based on the git hash of the currently checked-out commit, so local uncommitted edits won't force a rebuild. Not sure if we want to change that.

# Upgrade to Latest Tag

[Commit for this feature.](https://github.com/ronivay/XenOrchestraInstallerUpdater/commit/f87a20acc922a87eef908f1d3ceb2ce8a28f3f91)

Now, if you set `BRANCH` to `latest`, it will update you to the most recent tagged xen-orchestra release. I've found that these are usually more stable than just running on the master branch.