### PR TITLE
Add ability to install 3rd party plugins

### DIFF
--- a/sample.xo-install.cfg
+++ b/sample.xo-install.cfg
@@ -28,6 +28,9 @@ BRANCH="master"
 # (default) all plugins will be installed
 PLUGINS="all"
 
+# Additional 3rd-party plugins to fetch
+#ADDITIONAL_PLUGINS="https://github.com/user/repo.git,https://github.com/user/repo2.git"
+
 # NodeJS and Yarn are automatically updated when running update/install. Can be disabled but not recommended (installation might fail because of too old node.js or yarn)
 # Note that if nodejs is updated when script's update feature is used, it might not be possible to use rollback option anymore without manually downgrading nodejs version to previous one
 AUTOUPDATE="true"

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -27,6 +27,7 @@ PRESERVE=${PRESERVE:-"3"}
 XOUSER=${XOUSER:-"root"}
 CONFIGPATH="$(getent passwd $XOUSER | cut -d: -f6)"
 PLUGINS="${PLUGINS:-"none"}"
+ADDITIONAL_PLUGINS="${ADDITIONAL_PLUGINS:-"none"}"
 REPOSITORY="${REPOSITORY:-"https://github.com/vatesfr/xen-orchestra"}"
 OS_CHECK="${OS_CHECK:-"true"}"
 ARCH_CHECK="${ARCH_CHECK:-"true"}"


### PR DESCRIPTION
Depending on the situation, a user might have third party plugins that
are needed for their XO setup. We're using a mysql auth plugin, but
github has a handful of other third party plugins.

Added: config setting ADDITIONAL_PLUGINS to specify git repo URLs.
Added: InstallAdditionalXOPlugins function to download/update these
       repos and add them to the XO source tree before building.