### PR TITLE
Update to xo-install.sh to allow use of ECC/ECDSA certificates

### DIFF
--- a/xo-install.sh
+++ b/xo-install.sh
@@ -968,8 +968,8 @@ function CheckSystemd {
 # do not let the user define non functional cert/key pair
 function CheckCertificate {
 	if [[ "$HTTPS" == "true" ]]; then
-		local CERT="$(runcmd_stdout "openssl x509 -modulus -noout -in $PATH_TO_HTTPS_CERT | openssl md5")"
-		local KEY="$(runcmd_stdout "openssl rsa -modulus -noout -in $PATH_TO_HTTPS_KEY | openssl md5")"
+		local CERT="$(runcmd_stdout "openssl x509 -pubkey -noout -in $PATH_TO_HTTPS_CERT | openssl md5")"
+		local KEY="$(runcmd_stdout "openssl pkey -pubout -in $PATH_TO_HTTPS_KEY -outform PEM | openssl md5")"
 		if [[ "$CERT" != "$KEY" ]]; then
 			echo
 			printinfo "$PATH_TO_HTTPS_CERT:"


### PR DESCRIPTION
the CheckCertificate function fails when using ECC certificates
this change updates the openssl commands that compare certificate and key to ones that are algorithm-generic so that both RSA and ECC (and others?) can be compared and used.
based on answers here: https://security.stackexchange.com/questions/73127/how-can-you-check-if-a-private-key-and-certificate-match-in-openssl-with-ecdsa
and the other linked question: https://security.stackexchange.com/questions/56697/determine-if-private-key-belongs-to-certificate