### PR TITLE
add Oracle Linux 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Supported Linux distributions and versions:
 - Ubuntu 20.04
 - Ubuntu 18.04
 - Ubuntu 16.04
+- Oracle Linux 8
 
 Only x86_64 architecture is supported. For all those raspberry pi users out there, check [container](https://hub.docker.com/r/ronivay/xen-orchestra) instead.
 

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -197,11 +197,19 @@ function InstallDependenciesRPM {
 
     # Install necessary dependencies for XO build
 
+    # Set epel package name
+    EPEL_PACKAGE=epel-release
+
+    # Oracle Linux has a different epel package name
+    if [[ "$OSNAME" == "Oracle" ]] && [[ "$OSVERSION" == "8" ]]; then
+        EPEL_PACKAGE=oracle-epel-release-el8
+    fi
+
     # only install epel-release if doesn't exist
-    if [[ -z $(runcmd_stdout "rpm -qa epel-release") ]]; then
+    if [[ -z $(runcmd_stdout "rpm -qa ${EPEL_PACKAGE}") ]]; then
         echo
         printprog "Installing epel-repo"
-        runcmd "yum -y install epel-release"
+        runcmd "yum -y install ${EPEL_PACKAGE}"
         printok "Installing epel-repo"
     fi
 
@@ -1186,8 +1194,8 @@ function CheckOS {
         return 0
     fi
 
-    if [[ ! "$OSNAME" =~ ^(Debian|Ubuntu|CentOS|Rocky|AlmaLinux)$ ]]; then
-        printfail "Only Ubuntu/Debian/CentOS/Rocky/AlmaLinux supported"
+    if [[ ! "$OSNAME" =~ ^(Debian|Ubuntu|CentOS|Rocky|AlmaLinux|Oracle)$ ]]; then
+        printfail "Only Ubuntu/Debian/CentOS/Rocky/AlmaLinux/Oracle Linux supported"
         exit 1
     fi
 
@@ -1217,6 +1225,10 @@ function CheckOS {
         exit 1
     fi
 
+    if [[ "$OSNAME" == "Oracle" ]] && [[ "$OSVERSION" != "8" ]]; then
+        printfail "Only Oracle Linux 8 supported"
+        exit 1
+    fi
 }
 
 # we don't want anyone to attempt running this on xcp-ng/xenserver host, bail out if xe command is present


### PR DESCRIPTION
This adds support for Oracle Linux 8.

I used vagrant for testing.

Vagrantfile:

```ruby
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|

  config.vm.box = "generic/oracle8"

  config.vm.network "forwarded_port", guest: 80, host: 20080

  config.vm.provider "virtualbox" do |vb|
    vb.memory = "4096"
    vb.cpus = 2
  end

  config.vm.provision "shell", inline: <<-SHELL
    yum install -y git
    git clone -b eol8 https://github.com/copyrights/XenOrchestraInstallerUpdater.git
    cd XenOrchestraInstallerUpdater
    ./xo-install.sh --install
    firewall-cmd --add-service http
  SHELL
end
```