### PR TITLE
make sure test modules doesnt get linked

### DIFF
--- a/xo-install.sh
+++ b/xo-install.sh
@@ -457,7 +457,7 @@ function InstallXOPlugins {
 
     if [[ "$PLUGINS" == "all" ]]; then
         # shellcheck disable=SC1117
-        runcmd "find \"$INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/\" -maxdepth 1 -mindepth 1 -not -name \"xo-server\" -not -name \"xo-web\" -not -name \"xo-server-cloud\" -exec ln -sn {} \"$INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/node_modules/\" \;"
+        runcmd "find \"$INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/\" -maxdepth 1 -mindepth 1 -not -name \"xo-server\" -not -name \"xo-web\" -not -name \"xo-server-cloud\" -not -name \"xo-server-test\" -exec ln -sn {} \"$INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/node_modules/\" \;"
     else
         local PLUGIN
         IFS=',' read -ra PLUGIN <<<"$PLUGINS"

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -457,7 +457,7 @@ function InstallXOPlugins {
 
     if [[ "$PLUGINS" == "all" ]]; then
         # shellcheck disable=SC1117
-        runcmd "find \"$INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/\" -maxdepth 1 -mindepth 1 -not -name \"xo-server\" -not -name \"xo-web\" -not -name \"xo-server-cloud\" -not -name \"xo-server-test\" -exec ln -sn {} \"$INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/node_modules/\" \;"
+        runcmd "find \"$INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/\" -maxdepth 1 -mindepth 1 -not -name \"xo-server\" -not -name \"xo-web\" -not -name \"xo-server-cloud\" -not -name \"xo-server-test*\" -exec ln -sn {} \"$INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/node_modules/\" \;"
     else
         local PLUGIN
         IFS=',' read -ra PLUGIN <<<"$PLUGINS"


### PR DESCRIPTION
currently the xo-server-test and xo-server-test-plugin can still get linked and throws some errors about said plugins not being built. 
this stops that from happening