### PR TITLE
Fix detection of latest tagged release

### DIFF
--- a/xo-install.sh
+++ b/xo-install.sh
@@ -590,8 +590,7 @@ function PrepInstall {
 
     # get the latest available tagged release if branch is set to release. this is to make configuration more simple to user
     if [[ "$BRANCH" == "release" ]]; then
-        runcmd "cd $INSTALLDIR/xo-builds/xen-orchestra-$TIME"
-        local TAG=$(runcmd_stdout "git describe --tags '$(git rev-list --tags --max-count=1)'")
+        local TAG=$(runcmd_stdout "cd $INSTALLDIR/xo-builds/xen-orchestra-$TIME && git tag --sort=-committerdate | head -1")
 
         echo
         printinfo "Checking out latest tagged release '$TAG'"


### PR DESCRIPTION
The ability to find the latest tagged release is broken due to the runcmd function not preserving the current directory.

I could've used `local TAG=$(runcmd_stdout "cd $INSTALLDIR/xo-builds/xen-orchestra-$TIME && git describe --tags '$(cd $INSTALLDIR/xo-builds/xen-orchestra-$TIME && git rev-list --tags --max-count=1)'")` instead but it seemed a little too long.