### PR TITLE
Add ubuntu 22.04 to the checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Supported Linux distributions and versions:
 - Debian 10
 - Debian 9
 - Debian 8
+- Ubuntu 22.04
 - Ubuntu 20.04
 - Ubuntu 18.04
 - Ubuntu 16.04
@@ -135,7 +136,7 @@ deb:
 - libpng-dev
 - git
 - python-minimal
-- python2-minimal (Ubuntu 20/Debian 11 only, replaces python-minimal)
+- python2-minimal (Ubuntu 20/22 or Debian 11 only, replaces python-minimal)
 - libvhdi-utils
 - lvm2
 - nfs-common

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -292,7 +292,7 @@ function InstallDependenciesDeb {
     printok "Running apt-get update"
 
     #determine which python package is needed. Ubuntu 20/Debian 11 require python2-minimal, others have python-minimal
-    if [[ "$OSNAME" =~ ^(Ubuntu|Debian)$ ]] && [[ "$OSVERSION" =~ ^(20|11)$ ]]; then
+    if [[ "$OSNAME" =~ ^(Ubuntu|Debian)$ ]] && [[ "$OSVERSION" =~ ^(20|22|11)$ ]]; then
         local PYTHON="python2-minimal"
     else
         local PYTHON="python-minimal"
@@ -1276,8 +1276,8 @@ function CheckOS {
         exit 1
     fi
 
-    if [[ "$OSNAME" == "Ubuntu" ]] && [[ ! "$OSVERSION" =~ ^(16|18|20)$ ]]; then
-        printfail "Only Ubuntu 16/18/20 supported"
+    if [[ "$OSNAME" == "Ubuntu" ]] && [[ ! "$OSVERSION" =~ ^(16|18|20|22)$ ]]; then
+        printfail "Only Ubuntu 16/18/20/22 supported"
         exit 1
     fi
 


### PR DESCRIPTION
Adds Ubuntu 22.04 to the checks in `xo-install.sh`
Tested locally, appears to be working.

Almalinux 9 might also be worth looking at, I might spin one up later and give `xo-install.sh` a whirl.