### PR TITLE
fix: always use v4 localhost connection address for redis

### DIFF
--- a/xo-install.sh
+++ b/xo-install.sh
@@ -767,10 +767,10 @@ function InstallXO {
 
         echo
         printinfo "Fixing relative path to xo-web installation in xo-server configuration file"
-
         # shellcheck disable=SC1117
         runcmd "sed -i \"s%#'/any/url' = '/path/to/directory'%'/' = '$INSTALLDIR/xo-web/dist/'%\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/sample.config.toml"
-        sleep 2
+        printinfo "Changing redis connection address in xo-server configuration file"
+        runcmd "sed -i \"s%#uri = 'redis://redis.company.lan/42'%uri = 'redis://127.0.0.1:6379/0'%\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/sample.config.toml"
 
         if [[ "$PORT" != "80" ]]; then
             printinfo "Changing port in xo-server configuration file"


### PR DESCRIPTION
Xen Orchestra redis package nowadays prefers v6 localhost address `::1` when default `localhost` is defined in configuration. Default redis.conf from rpm package doesn't listen v6, but only v4 so xo-server fails to start.

This changes xo-server config to use 127.0.0.1 always. Fixes #135 