### PR TITLE
Add ability to customize xo-src with local patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 xo-install.cfg
+patches/*
 logs/*

--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ Note that for obvious reasons some of the proxy features seen in Xen Orchestra U
 
 Plugins are installed according to what is specified in `PLUGINS` variable inside `xo-install.cfg` configuration file. By default all available plugins that are part of xen orchestra repository are installed. This list can be narrowed down if needed and 3rd party plugins included.
 
+#### Patches
+
+The script allows to apply extra patches during the Xen Orchestra build phase. If e.g. any local patches are needed, they can be dropped into the patches/ subfolder. Every file in there with the `.patch` suffix will be applied during building.
+
+This allows for local customization of XO. N.B. xo-install is not shipping with any patches, this is for advanced users.
+
 ### Image
 
 If you don't want to first install a VM and then use `xo-install.sh` script on it, you have the possibility to import VM image which has everything already setup. Use `xo-vm-import.sh` to do this, it'll download a prebuilt Debian 11 image which has Xen Orchestra and XenOrchestraInstallerUpdater installed.

--- a/sample.xo-install.cfg
+++ b/sample.xo-install.cfg
@@ -42,6 +42,9 @@ BRANCH="master"
 # default: ./logs
 #LOGPATH=
 
+# Apply patches to sourcecode
+APPLY_PATCHES="true"
+
 # Only one PLUGINS variable can be used at a time. Comment out the other one if you change these below. Comment out both if you don't want any plugins to be installed.
 
 # Comma separated list of plugins to be installed, check README for more information. Note that 3rd party plugins defined below should be listed here as well with their name eq. repo1,repo2 etc.

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -662,6 +662,20 @@ function PrepInstall {
 
 }
 
+function ApplyPatches {
+
+	set -euo pipefail
+
+	trap ErrorHandling ERR INT
+
+	for patch in $(dirname $0)/patches/*.patch; do
+		runcmd "cat $(dirname $0)/patches/$(basename $patch) | (cd $INSTALLDIR/xo-builds/xen-orchestra-$TIME && git apply -)"
+	done
+	echo
+	printok "Applying patches"
+
+}
+
 # run actual xen orchestra installation. procedure is the same for new installation and update. we always build it from scratch.
 function InstallXO {
 
@@ -700,6 +714,9 @@ function InstallXO {
 
     # Fetch 3rd party plugins source code
     InstallAdditionalXOPlugins
+
+    # Apply extra patches
+    ApplyPatches
 
     echo
     printinfo "xo-server and xo-web build takes quite a while. Grab a cup of coffee and lay back"


### PR DESCRIPTION
Some users prefer to use some locally maintained patches to customize xo.
Allow for these patches to be stored in the `./patches` subdir and applied to the xo git checkout during build.

This is an... "advanced" feature... Not sure how you feel about it considering the last sentence of your readme. I think *not* doing any patching of the sources is the right approach, but offering the ability for interested users to apply their own patches is sensible. Support effort should be nil, as people able to build their own patches can also fix them.