### PR TITLE
chore: remove unused libxml2 pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ rpm:
 - cifs-utils
 - lvm2
 - ntfs-3g
-- libxml2
 - sudo (if set in xo-install.cfg)
 
 deb:
@@ -146,7 +145,6 @@ deb:
 - gnupg (debian 10/11)
 - software-properties-common (ubuntu)
 - ntfs-3g
-- libxml2-utils
 - sudo (if set in xo-install.cfg)
 ```
 

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -204,9 +204,9 @@ function InstallDependenciesRPM {
 
     # install packages
     echo
-    printprog "Installing build dependencies, redis server, python3, git, nfs-utils, cifs-utils, lvm2, ntfs-3g, libxml2"
-    runcmd "yum -y install gcc gcc-c++ make openssl-devel redis libpng-devel python3 git nfs-utils cifs-utils lvm2 ntfs-3g libxml2"
-    printok "Installing build dependencies, redis server, python3, git, nfs-utils, cifs-utils, lvm2, ntfs-3g, libxml2"
+    printprog "Installing build dependencies, redis server, python3, git, nfs-utils, cifs-utils, lvm2, ntfs-3g"
+    runcmd "yum -y install gcc gcc-c++ make openssl-devel redis libpng-devel python3 git nfs-utils cifs-utils lvm2 ntfs-3g"
+    printok "Installing build dependencies, redis server, python3, git, nfs-utils, cifs-utils, lvm2, ntfs-3g"
 
     # only run automated node install if executable not found
     if [[ -z $(runcmd_stdout "command -v node") ]]; then
@@ -288,9 +288,9 @@ function InstallDependenciesDeb {
 
     # install packages
     echo
-    printprog "Installing build dependencies, redis server, python3-minimal, git, libvhdi-utils, lvm2, nfs-common, cifs-utils, curl, ntfs-3g, libxml2-utils"
-    runcmd "apt-get install -y build-essential redis-server libpng-dev git libvhdi-utils python3-minimal lvm2 nfs-common cifs-utils curl ntfs-3g libxml2-utils"
-    printok "Installing build dependencies, redis server, python3-minimal, git, libvhdi-utils, lvm2, nfs-common, cifs-utils, curl, ntfs-3g, libxml2-utils"
+    printprog "Installing build dependencies, redis server, python3-minimal, git, libvhdi-utils, lvm2, nfs-common, cifs-utils, curl, ntfs-3g"
+    runcmd "apt-get install -y build-essential redis-server libpng-dev git libvhdi-utils python3-minimal lvm2 nfs-common cifs-utils curl ntfs-3g"
+    printok "Installing build dependencies, redis server, python3-minimal, git, libvhdi-utils, lvm2, nfs-common, cifs-utils, curl, ntfs-3g"
 
     # Install apt-transport-https and ca-certificates because of yarn https repo url
     echo


### PR DESCRIPTION
libxml2 (deb) and libxml2-utils (rpm) was introduced by XO sources requiring it for xmllint which isn't used for source installations