### PR TITLE
Adding * to catch all other read responses to an unneeded upgrade to NOT continue the upgrade (standardized with the rest of the script).

### DIFF
--- a/xo-install.sh
+++ b/xo-install.sh
@@ -623,7 +623,7 @@ function PrepInstall {
                 y)
                     :
                     ;;
-                n)
+                *)
                     printinfo "Cleaning up install directory: $INSTALLDIR/xo-builds/xen-orchestra-$TIME"
                     runcmd "rm -rf $INSTALLDIR/xo-builds/xen-orchestra-$TIME"
                     exit 0


### PR DESCRIPTION
While using the interactive prompt to test whether the script will update when there are no updates available, I noticed that selecting anything other than lower-case "n" results in an upgrade taking place.  I think this runs counter to the logic displayed in the rest of the script: that is, if the response is not "y" it should be treated as "n".

This was also annoying because my original response was upper-case "N" (which the prompt requested for "no"), but the upgrade happened anyway.

As an aside, it seems weird that (I think) [this line](https://github.com/ronivay/XenOrchestraInstallerUpdater/blob/70ea9a0509ce35329349a078db56758591b81f67/xo-install.sh#L621) is supposed to convert an empty response to "n", but having a case statement that catches anything with * makes said line redundant.  At first I thought it was an attempt to lower-case the response, but the correct syntax (Bash 4) for that would be `answer=${answer,,}`

