### PR TITLE
chore: remove ubuntu 18 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Supported Linux distributions and versions:
 - Debian 10
 - Ubuntu 22.04
 - Ubuntu 20.04
-- Ubuntu 18.04
 
 Only x86_64 architecture is supported. For all those raspberry pi users out there, check [container](https://hub.docker.com/r/ronivay/xen-orchestra) instead.
 

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -1289,8 +1289,8 @@ function CheckOS {
         exit 1
     fi
 
-    if [[ "$OSNAME" == "Ubuntu" ]] && [[ ! "$OSVERSION" =~ ^(18|20|22)$ ]]; then
-        printfail "Only Ubuntu 18/20/22 supported"
+    if [[ "$OSNAME" == "Ubuntu" ]] && [[ ! "$OSVERSION" =~ ^(20|22)$ ]]; then
+        printfail "Only Ubuntu 20/22 supported"
         exit 1
     fi
 


### PR DESCRIPTION
End of support in 6/2023. node.js 18.x not supported in nodesource repo

"Resolves" issue #168