### PR TITLE
feat: add automatic yarn cache cleanup with a config option

### DIFF
--- a/sample.xo-install.cfg
+++ b/sample.xo-install.cfg
@@ -58,6 +58,11 @@ PLUGINS="all"
 # options: true/false
 AUTOUPDATE="true"
 
+# yarn cache can consume a lot of disk space over time. Setting this to true will clear cache after update.
+# this can have a negative impact on how long update will take with slower internet connections
+# options: true/false
+#YARN_CACHE_CLEANUP="false"
+
 # enable/disable OS check. Installation refuses to run on any other than supported OS versions if this is enabled. Can be disabled for experimental purposes.
 # options: true/false
 OS_CHECK="true"

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -48,6 +48,7 @@ USESUDO="${USESUDO:-"false"}"
 GENSUDO="${GENSUDO:-"false"}"
 INSTALL_REPOS="${INSTALL_REPOS:-"true"}"
 SYSLOG_TARGET="${SYSLOG_TARGET:-""}"
+YARN_CACHE_CLEANUP="${YARN_CACHE_CLEANUP:-"false"}"
 
 # set variables not changeable in configfile
 TIME=$(date +%Y%m%d%H%M)
@@ -949,6 +950,14 @@ function UpdateXO {
     done
     printok "Removing old inactive installations after update. Leaving $PRESERVE latest"
     echo
+
+    # clear yarn cache if defined in configuration
+    if [[ "$YARN_CACHE_CLEANUP" == "true" ]]; then
+        printprog "Cleaning yarn cache"
+        runcmd "yarn cache clean"
+        printok "Cleaning yarn cache"
+        echo
+    fi
 }
 
 function InstallXOProxy {


### PR DESCRIPTION
Add config option `YARN_CACHE_CLEANUP`. When set to true, will run `yarn cache clean` at the end of an update. Defaults to false.

Resolves #182 