### PR TITLE
Support Debian 12 "bookworm"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Supported Linux distributions and versions:
 - AlmaLinux 8
 - Rocky Linux 9
 - Rocky Linux 8
+- Debian 12
 - Debian 11
 - Debian 10
 - Ubuntu 22.04

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -300,11 +300,11 @@ function InstallDependenciesDeb {
     runcmd "apt-get install -y apt-transport-https ca-certificates"
     printok "Installing apt-transport-https and ca-certificates packages to support https repos"
 
-    if [[ "$OSNAME" == "Debian" ]] && [[ "$OSVERSION" =~ ^(10|11)$ ]]; then
+    if [[ "$OSNAME" == "Debian" ]] && [[ "$OSVERSION" =~ ^(10|11|12)$ ]]; then
         echo
-        printprog "Debian 10/11, so installing gnupg also"
+        printprog "Debian 10/11/12, so installing gnupg also"
         runcmd "apt-get install gnupg -y"
-        printok "Debian 10/11, so installing gnupg also"
+        printok "Debian 10/11/12, so installing gnupg also"
     fi
 
     # install setcap for non-root port binding if missing
@@ -1293,8 +1293,8 @@ function CheckOS {
         exit 1
     fi
 
-    if [[ "$OSNAME" == "Debian" ]] && [[ ! "$OSVERSION" =~ ^(10|11)$ ]]; then
-        printfail "Only Debian 10/11 supported"
+    if [[ "$OSNAME" == "Debian" ]] && [[ ! "$OSVERSION" =~ ^(10|11|12)$ ]]; then
+        printfail "Only Debian 10/11/12 supported"
         exit 1
     fi
 


### PR DESCRIPTION
Debian 12 "Bookworm" has been released and seems from my testing to create no breaking changes for XOIU. I have tested on a fresh Debian 12 installation with the changes included in this pull request and XOIU installs and runs without fault.