### PR TITLE
Add OracleLinux

### DIFF
--- a/xo-install.sh
+++ b/xo-install.sh
@@ -1285,8 +1285,8 @@ function CheckOS {
         return 0
     fi
 
-    if [[ ! "$OSNAME" =~ ^(Debian|Ubuntu|CentOS|Rocky|AlmaLinux)$ ]]; then
-        printfail "Only Ubuntu/Debian/CentOS/Rocky/AlmaLinux supported"
+    if [[ ! "$OSNAME" =~ ^(Debian|Ubuntu|CentOS|Rocky|AlmaLinux|Oracle)$ ]]; then
+        printfail "Only Ubuntu/Debian/CentOS/Rocky/AlmaLinux/Oracle supported"
         exit 1
     fi
 


### PR DESCRIPTION
## summary

Oracle Linux is as compatible as Redhat Enterprise Linux.
Many people might use it instead of CentOS.

## Modified Point

Changed OSNAME in the function CheckOS on my Oracle Linux environment.


