### PR TITLE
fix: workaround for failing rhel installations for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Supported Linux distributions and versions:
 - Ubuntu 22.04
 - Ubuntu 20.04
 
+NOTE: RHEL based distros cannot do file level restore from backups in XO due to missing libvhdi-tools. See: https://github.com/ronivay/XenOrchestraInstallerUpdater/issues/256
+
 Only x86_64 architecture is supported. For all those raspberry pi users out there, check [container](https://hub.docker.com/r/ronivay/xen-orchestra) instead.
 
 All OS/Architecture checks can be disabled in `xo-install.cfg` for experimental purposes. Not recommended obviously.

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -241,19 +241,20 @@ function InstallDependenciesRPM {
         printok "Installing yarn"
     fi
 
+    # Disabled for now due to forensics.cert.org going away
     # only install libvhdi-tools if vhdimount is not present
-    if [[ -z $(runcmd_stdout "command -v vhdimount") ]]; then
-        echo
-        printprog "Installing libvhdi-tools"
-        if [[ "$INSTALL_REPOS" == "true" ]]; then
-            runcmd "rpm -ivh https://forensics.cert.org/cert-forensics-tools-release-el${OSVERSION}.rpm"
-            runcmd "sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/cert-forensics-tools.repo"
-            runcmd "dnf --enablerepo=forensics install -y libvhdi-tools"
-        else
-            runcmd "dnf install -y libvhdi-tools"
-        fi
-        printok "Installing libvhdi-tools"
-    fi
+    #    if [[ -z $(runcmd_stdout "command -v vhdimount") ]]; then
+    #        echo
+    #        printprog "Installing libvhdi-tools"
+    #        if [[ "$INSTALL_REPOS" == "true" ]]; then
+    #            runcmd "rpm -ivh https://forensics.cert.org/cert-forensics-tools-release-el${OSVERSION}.rpm"
+    #            runcmd "sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/cert-forensics-tools.repo"
+    #            runcmd "dnf --enablerepo=forensics install -y libvhdi-tools"
+    #        else
+    #            runcmd "dnf install -y libvhdi-tools"
+    #        fi
+    #        printok "Installing libvhdi-tools"
+    #    fi
 
     echo
     printprog "Enabling and starting redis service"


### PR DESCRIPTION
This is just a workaround for issue #256 to get RHEL installations to go through. This makes them unable to do file level restore from backups until another source for libvhdi-tools package is implemented.