### PR TITLE
Adding publicUrl Option for XO Lite Integration

### DIFF
--- a/sample.xo-install.cfg
+++ b/sample.xo-install.cfg
@@ -121,3 +121,8 @@ PRESERVE="3"
 # Configurable network-timeout setting for yarn, in ms.
 # default: 300000 = 300sec
 #YARN_NETWORK_TIMEOUT="300000"
+
+# Change the URL communicated to XO Lite to be used to
+# access Xen Orchestra.  By default, this is set to the
+# IPv4 address of the Xen Orchestra server.
+#PUBLIC_URL="https://xoa.company.lan"

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -828,7 +828,7 @@ function InstallXO {
 
         if [[ -n "$PUBLIC_URL" ]]; then
             printinfo "Setting publicUrl in xo-server configuration file"
-            runcmd "sed -i \"/^#publicUrl =.*/a publicUrl= '$PUBLIC_URL'\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/sample.config.toml"
+            runcmd "sed -i \"/^#publicUrl =.*/a publicUrl = '$PUBLIC_URL'\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/sample.config.toml"
         fi
 
         printinfo "Activating modified configuration file"

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -51,6 +51,7 @@ INSTALL_REPOS="${INSTALL_REPOS:-"true"}"
 SYSLOG_TARGET="${SYSLOG_TARGET:-""}"
 YARN_CACHE_CLEANUP="${YARN_CACHE_CLEANUP:-"false"}"
 YARN_NETWORK_TIMEOUT="${YARN_NETWORK_TIMEOUT:-"300000"}"
+PUBLIC_URL="${PUBLIC_URL:-""}"
 
 # set variables not changeable in configfile
 TIME=$(date +%Y%m%d%H%M)
@@ -823,6 +824,11 @@ function InstallXO {
             printinfo "Enabling remote syslog in xo-server configuration file"
             runcmd "sed -i \"s%#\[logs.transport.syslog\]%\[logs.transport.syslog\]%\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/sample.config.toml"
             runcmd "sed -i \"/^\[logs.transport.syslog.*/a target = '$SYSLOG_TARGET'\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/sample.config.toml"
+        fi
+
+        if [[ -n "$PUBLIC_URL" ]]; then
+            printinfo "Setting publicUrl in xo-server configuration file"
+            runcmd "sed -i \"/^#publicUrl =.*/a publicUrl= '$PUBLIC_URL'\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/sample.config.toml"
         fi
 
         printinfo "Activating modified configuration file"


### PR DESCRIPTION
Allow configuration of the publicUrl option in the XOA config.  Original documentation in config.toml:

```
# Public URL to connect to this XO
#
# This optional entry is used to communicate to external entities (e.g. XO Lite)
# how to connect to this XO.
#
# It SHOULD be defined in case the IP address of the current machine is not
# good enough (e.g. a domain name must be used or there is a reverse proxy).
#publicUrl = 'https://xoa.company.lan'
```

Ran an install with the variable set and config was generated successfully:

```
#publicUrl = 'https://xoa.company.lan'
publicUrl= 'https://hostname.domain.net'
```