### PR TITLE
Add optional flag to enable libvhdi-tools install on RHEL installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Supported Linux distributions and versions:
 - Ubuntu 22.04
 - Ubuntu 20.04
 
-NOTE: By default, libvhdi-tools is not installed on RHEL based distros; so file-level restores from delta backups within XOA will not work.  However, users MAY install libvhdi-tools via a small, third-party maintained by a user of XenOrchestraInstallerUpdater specifically for XenOrchestraInstallerUpdater in order to re-enable file-level restore. To do so, set the INSTALL_EL_LIBVHDI variable to "true" in xo-install.cfg.  See: https://github.com/ronivay/XenOrchestraInstallerUpdater/pull/274
+NOTE: By default, libvhdi-tools is not installed on RHEL based distros; so file-level restores from delta backups within XO will not work.  However, users MAY install libvhdi-tools via a small, third-party maintained by a user of XenOrchestraInstallerUpdater specifically for XenOrchestraInstallerUpdater in order to re-enable file-level restore. To do so, set the INSTALL_EL_LIBVHDI variable to "true" in xo-install.cfg.  See: https://github.com/ronivay/XenOrchestraInstallerUpdater/pull/274
 
 Only x86_64 architecture is supported. For all those raspberry pi users out there, check [container](https://hub.docker.com/r/ronivay/xen-orchestra) instead.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Supported Linux distributions and versions:
 - Ubuntu 22.04
 - Ubuntu 20.04
 
-NOTE: RHEL based distros cannot do file level restore from backups in XO due to missing libvhdi-tools. See: https://github.com/ronivay/XenOrchestraInstallerUpdater/issues/256
+NOTE: By default, libvhdi-tools is not installed on RHEL based distros; so file-level restores from delta backups within XOA will not work.  However, users MAY install libvhdi-tools via a small, third-party maintained by a user of XenOrchestraInstallerUpdater specifically for XenOrchestraInstallerUpdater in order to re-enable file-level restore. To do so, set the INSTALL_EL_LIBVHDI variable to "true" in xo-install.cfg.  See: https://github.com/ronivay/XenOrchestraInstallerUpdater/pull/274
 
 Only x86_64 architecture is supported. For all those raspberry pi users out there, check [container](https://hub.docker.com/r/ronivay/xen-orchestra) instead.
 

--- a/sample.xo-install.cfg
+++ b/sample.xo-install.cfg
@@ -121,6 +121,13 @@ PRESERVE="3"
 # default: true
 #INSTALL_REPOS="true"
 
+# If set to true, this will install a small third-party copr repository necessary to install the libvhdi and libvhdi-tools rpms as-well-as the libvhdi and libvhdi-tools rpms.
+# If set to false, this repository and the corresponding libvhdi and libvhdi-tools rpms will not be installed.  As as result, file-level restore from delta backups within XOA will NOT work.
+# This is specific to Redhat/RockyLinux/AlmaLinux installs ONLY.
+# options: true/false
+# default: false
+#INSTALL_EL_LIBVHDI="false"
+
 # Send xo-server logs to remote syslog
 # syntax is: <protocol>://<target-address>:<port>
 # supported protocols are udp and tcp

--- a/sample.xo-install.cfg
+++ b/sample.xo-install.cfg
@@ -122,8 +122,9 @@ PRESERVE="3"
 #INSTALL_REPOS="true"
 
 # If set to true, this will install a small third-party copr repository necessary to install the libvhdi and libvhdi-tools rpms as-well-as the libvhdi and libvhdi-tools rpms.
-# If set to false, this repository and the corresponding libvhdi and libvhdi-tools rpms will not be installed.  As as result, file-level restore from delta backups within XOA will NOT work.
+# If set to false, this repository and the corresponding libvhdi and libvhdi-tools rpms will not be installed.  As as result, file-level restore from delta backups within XO will NOT work.
 # This is specific to Redhat/RockyLinux/AlmaLinux installs ONLY.
+# Note that INSTALL_REPOS must also be set to "true" for the copr repository to be enabled.
 # options: true/false
 # default: false
 #INSTALL_EL_LIBVHDI="false"

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -49,6 +49,7 @@ ACME_EMAIL="${ACME_EMAIL:-""}"
 ACME_CA="${ACME_CA:-"letsencrypt/production"}"
 USESUDO="${USESUDO:-"false"}"
 GENSUDO="${GENSUDO:-"false"}"
+INSTALL_EL_LIBVHDI="${INSTALL_EL_LIBVHDI:-"false"}"
 INSTALL_REPOS="${INSTALL_REPOS:-"true"}"
 SYSLOG_TARGET="${SYSLOG_TARGET:-""}"
 YARN_CACHE_CLEANUP="${YARN_CACHE_CLEANUP:-"false"}"
@@ -250,9 +251,9 @@ function InstallDependenciesRPM {
         printprog "Installing libvhdi-tools"
         if [[ "$INSTALL_REPOS" == "true" ]] && [[ "$INSTALL_EL_LIBVHDI" == "true" ]]; then
             runcmd "dnf copr enable -y bnerickson/libvhdi"
-        else
-            runcmd "dnf install -y libvhdi-tools"
         fi
+
+        runcmd "dnf install -y libvhdi-tools"
         printok "Installing libvhdi-tools"
     fi
 

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -244,20 +244,17 @@ function InstallDependenciesRPM {
         printok "Installing yarn"
     fi
 
-    # Disabled for now due to forensics.cert.org going away
-    # only install libvhdi-tools if vhdimount is not present
-    #    if [[ -z $(runcmd_stdout "command -v vhdimount") ]]; then
-    #        echo
-    #        printprog "Installing libvhdi-tools"
-    #        if [[ "$INSTALL_REPOS" == "true" ]]; then
-    #            runcmd "rpm -ivh https://forensics.cert.org/cert-forensics-tools-release-el${OSVERSION}.rpm"
-    #            runcmd "sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/cert-forensics-tools.repo"
-    #            runcmd "dnf --enablerepo=forensics install -y libvhdi-tools"
-    #        else
-    #            runcmd "dnf install -y libvhdi-tools"
-    #        fi
-    #        printok "Installing libvhdi-tools"
-    #    fi
+    # Only install libvhdi-tools if vhdimount is not present
+    if [[ -z $(runcmd_stdout "command -v vhdimount") ]]; then
+        echo
+        printprog "Installing libvhdi-tools"
+        if [[ "$INSTALL_REPOS" == "true" ]] && [[ "$INSTALL_EL_LIBVHDI" == "true" ]]; then
+            runcmd "dnf copr enable -y bnerickson/libvhdi"
+        else
+            runcmd "dnf install -y libvhdi-tools"
+        fi
+        printok "Installing libvhdi-tools"
+    fi
 
     echo
     printprog "Enabling and starting redis service"


### PR DESCRIPTION
This PR adds a INSTALL_EL_LIBVHDI variable to enable the bnerickson/libvhdi COPR repo on and subsequently re-enable libvhdi-tools installs on RHEL-based distros.  See: https://github.com/ronivay/XenOrchestraInstallerUpdater/issues/256

COPR URL: https://copr.fedorainfracloud.org/coprs/bnerickson/libvhdi/

FYI el10 is enabled in the copr repo, but builds are failing there at the moment.  It's not something I'll prioritize until Redhat 10 sees release.