### PR TITLE
fix: missing redis variable for rhel <10

### DIFF
--- a/xo-install.sh
+++ b/xo-install.sh
@@ -1294,6 +1294,8 @@ function CheckOS {
         # Since version 10, redis is replaced with valkey
         if [[ $OSVERSION -ge 10 ]]; then
             REDIS=0
+        else
+            REDIS=1
         fi
     fi
 


### PR DESCRIPTION
reported in: https://github.com/ronivay/XenOrchestraInstallerUpdater/issues/305
caused by: https://github.com/ronivay/XenOrchestraInstallerUpdater/pull/304