### PR TITLE
feat: change v6 interface as default

### DIFF
--- a/sample.xo-install.cfg
+++ b/sample.xo-install.cfg
@@ -138,8 +138,3 @@ PRESERVE="3"
 # Configurable network-timeout setting for yarn, in ms.
 # default: 300000 = 300sec
 #YARN_NETWORK_TIMEOUT="300000"
-
-# Enable/Disable XO 6 UI build, accessible at /v6
-# This is actively developed and enabling it might break install/update
-# default: false
-#INCLUDE_V6="false"


### PR DESCRIPTION
This removes the static config for v5 interface making v6 the default. `INCLUDE_V6` configuration option is removed as v6 interface is built by default.

reported in: https://github.com/ronivay/XenOrchestraInstallerUpdater/issues/335 & https://github.com/ronivay/XenOrchestraInstallerUpdater/issues/331