### PR TITLE
Add Debian 13 to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Supported Linux distributions and versions:
 - Rocky Linux 10
 - Rocky Linux 9
 - Rocky Linux 8
+- Debian 13
 - Debian 12
 - Debian 11
 - Debian 10


### PR DESCRIPTION
Update documentation to reflect added support for Debian 13, added 13 August 2025, per commit: [debian](https://github.com/ronivay/XenOrchestraInstallerUpdater/commit/9a2f4c4a80851d5d8c796131ab18e0c37be0442e)