### PR TITLE
chore: remove support for EOL OS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Supported Linux distributions and versions:
 
 - CentOS 10 Stream
 - CentOS 9 Stream
-- CentOS 8 Stream
 - AlmaLinux 10
 - AlmaLinux 9
 - AlmaLinux 8
@@ -48,10 +47,8 @@ Supported Linux distributions and versions:
 - Debian 13
 - Debian 12
 - Debian 11
-- Debian 10
 - Ubuntu 24.04
 - Ubuntu 22.04
-- Ubuntu 20.04
 
 NOTE: By default, libvhdi-tools is not installed on RHEL based distros; so file-level restores from delta backups within XO will not work.  However, users MAY install libvhdi-tools via a small, third-party maintained by a user of XenOrchestraInstallerUpdater specifically for XenOrchestraInstallerUpdater in order to re-enable file-level restore. To do so, set the INSTALL_EL_LIBVHDI variable to "true" in xo-install.cfg.  See: https://github.com/ronivay/XenOrchestraInstallerUpdater/pull/274
 

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -308,11 +308,11 @@ function InstallDependenciesDeb {
     runcmd "apt-get install -y apt-transport-https ca-certificates"
     printok "Installing apt-transport-https and ca-certificates packages to support https repos"
 
-    if [[ "$OSNAME" == "Debian" ]] && [[ "$OSVERSION" =~ ^(10|11|12|13)$ ]]; then
+    if [[ "$OSNAME" == "Debian" ]] && [[ "$OSVERSION" =~ ^(11|12|13)$ ]]; then
         echo
-        printprog "Debian 10/11/12/13, so installing gnupg also"
+        printprog "Debian 11/12/13, so installing gnupg also"
         runcmd "apt-get install gnupg -y"
-        printok "Debian 10/11/12/13, so installing gnupg also"
+        printok "Debian 11/12/13, so installing gnupg also"
     fi
 
     # Debian 13 doesn't come with libfuse2 anymore
@@ -1326,8 +1326,8 @@ function CheckOS {
         exit 1
     fi
 
-    if [[ "$OSNAME" == "CentOS" ]] && [[ ! "$OSVERSION" =~ ^(8|9|10)$ ]]; then
-        printfail "Only CentOS 8/9/10 supported"
+    if [[ "$OSNAME" == "CentOS" ]] && [[ ! "$OSVERSION" =~ ^(9|10)$ ]]; then
+        printfail "Only CentOS 9/10 supported"
         exit 1
     fi
 
@@ -1341,13 +1341,13 @@ function CheckOS {
         exit 1
     fi
 
-    if [[ "$OSNAME" == "Debian" ]] && [[ ! "$OSVERSION" =~ ^(10|11|12|13)$ ]]; then
-        printfail "Only Debian 10/11/12/13 supported"
+    if [[ "$OSNAME" == "Debian" ]] && [[ ! "$OSVERSION" =~ ^(11|12|13)$ ]]; then
+        printfail "Only Debian 11/12/13 supported"
         exit 1
     fi
 
-    if [[ "$OSNAME" == "Ubuntu" ]] && [[ ! "$OSVERSION" =~ ^(20|22|24)$ ]]; then
-        printfail "Only Ubuntu 20/22/24 supported"
+    if [[ "$OSNAME" == "Ubuntu" ]] && [[ ! "$OSVERSION" =~ ^(22|24)$ ]]; then
+        printfail "Only Ubuntu 22/24 supported"
         exit 1
     fi
 


### PR DESCRIPTION
Debian 10, Ubuntu 20.04 and CentOS Stream 8 are EOL, remove support from this script