### PR TITLE
Add support for ubuntu 26.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Supported Linux distributions and versions:
 - Debian 13
 - Debian 12
 - Debian 11
+- Ubuntu 26.04
 - Ubuntu 24.04
 - Ubuntu 22.04
 

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -315,13 +315,13 @@ function InstallDependenciesDeb {
         printok "Debian 11/12/13, so installing gnupg also"
     fi
 
-    # Debian 13 doesn't come with libfuse2 anymore
+    # Debian 13 / Ubuntu 26.04 don't come with libfuse2 anymore
     # it needs to be installed specifically as XO relies on it for now
-    if [[ "$OSNAME" == "Debian" ]] && [[ "$OSVERSION" == 13 ]]; then
+    if { [[ "$OSNAME" == "Debian" ]] && [[ "$OSVERSION" == 13 ]]; } || { [[ "$OSNAME" == "Ubuntu" ]] && [[ "$OSVERSION" == 26 ]]; }; then
         echo
-        printprog "Debian 13, so installing libfuse2t64"
+        printprog "Installing libfuse2t64"
         runcmd "apt-get install libfuse2t64 -y"
-        printok "Debian 13, so installing libfuse2t64"
+        printok "Installing libfuse2t64"
     fi
 
     # install setcap for non-root port binding if missing
@@ -1350,8 +1350,8 @@ function CheckOS {
         exit 1
     fi
 
-    if [[ "$OSNAME" == "Ubuntu" ]] && [[ ! "$OSVERSION" =~ ^(22|24)$ ]]; then
-        printfail "Only Ubuntu 22/24 supported"
+    if [[ "$OSNAME" == "Ubuntu" ]] && [[ ! "$OSVERSION" =~ ^(22|24|26)$ ]]; then
+        printfail "Only Ubuntu 22/24/26 supported"
         exit 1
     fi
 


### PR DESCRIPTION
Appreciate that 26.04 only dropped a few days ago, but I rushed to upgrade, realised XO wouldn't run and then had to fix up! 

Given the fix was so trivial as it is the same code path as Debian 13 I figured a quick PR would be acceptable. Let me know if there is more needed/wanted here.

Tested this on my main system (previously 24.04 running XO, upgraded to 26.04) as well as on a fresh 24.04 VM, a fresh 26.04 VM and a fresh Debian 13 VM. Install/update works as expected.