### PR TITLE
Replace manual cap_net_bind_service setting with bounded capability setting in the systemd service file

### DIFF
--- a/xo-install.sh
+++ b/xo-install.sh
@@ -324,14 +324,6 @@ function InstallDependenciesDeb {
         printok "Installing libfuse2t64"
     fi
 
-    # install setcap for non-root port binding if missing
-    if [[ -z $(runcmd_stdout "command -v setcap") ]]; then
-        echo
-        printprog "Installing setcap"
-        runcmd "apt-get install -y libcap2-bin"
-        printok "Installing setcap"
-    fi
-
     # only run automated node install if executable not found
     if [[ -z $(runcmd_stdout "command -v node") ]] || [[ -z $(runcmd_stdout "command -v npm") ]]; then
         echo
@@ -756,8 +748,8 @@ function InstallXO {
         runcmd "sed -i \"/SyslogIdentifier=.*/a User=$XOUSER\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/xo-server.service"
 
         if [ "$PORT" -le "1024" ]; then
-            printinfo "Adding CapabilityBoundingSet and AmbientCapabilities to systemd config"
-            runcmd "sed -i \"/SyslogIdentifier=.*/a CapabilityBoundingSet=CAP_NET_BIND_SERVICE\nAmbientCapabilities=CAP_NET_BIND_SERVICE\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/xo-server.service"
+            printinfo "Adding AmbientCapabilities to systemd config"
+            runcmd "sed -i \"/SyslogIdentifier=.*/a AmbientCapabilities=CAP_NET_BIND_SERVICE\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/xo-server.service"
         fi
     fi
 

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -756,21 +756,8 @@ function InstallXO {
         runcmd "sed -i \"/SyslogIdentifier=.*/a User=$XOUSER\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/xo-server.service"
 
         if [ "$PORT" -le "1024" ]; then
-            local NODEBINARY=$(runcmd_stdout "command -v node")
-            if [[ -L "$NODEBINARY" ]]; then
-                local NODEBINARY=$(runcmd_stdout "readlink -e $NODEBINARY")
-            fi
-
-            if [[ -n "$NODEBINARY" ]]; then
-                printprog "Attempting to set cap_net_bind_service permission for $NODEBINARY"
-                runcmd "setcap 'cap_net_bind_service=+ep' $NODEBINARY" && printok "Attempting to set cap_net_bind_service permission for $NODEBINARY" ||
-                    {
-                        printfail "Attempting to set cap_net_bind_service permission for $NODEBINARY"
-                        echo "	Non-privileged user might not be able to bind to <1024 port. xo-server won't start most likely"
-                    }
-            else
-                printfail "Can't find node executable, or it's a symlink to non existing file. Not trying to setcap. xo-server won't start most likely"
-            fi
+            printinfo "Adding CapabilityBoundingSet and AmbientCapabilities to systemd config"
+            runcmd "sed -i \"/SyslogIdentifier=.*/a CapabilityBoundingSet=CAP_NET_BIND_SERVICE\nAmbientCapabilities=CAP_NET_BIND_SERVICE\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/xo-server.service"
         fi
     fi
 


### PR DESCRIPTION
Related Issue: https://github.com/ronivay/XenOrchestraInstallerUpdater/issues/370

This is, I think, a more secure way of setting the appropriate capabilities such that nodejs can start a webserver as an unprivileged user on a port <= 1024.  Updates to nodejs should no longer cause the capability to be lost either , so the related issue will no longer crop up.