### PR TITLE
Add reverse proxy options to generated XO configuration

### DIFF
--- a/sample.xo-install.cfg
+++ b/sample.xo-install.cfg
@@ -41,6 +41,19 @@ SELFUPGRADE=true
 # no effect to Xen Orchestra proxy
 CONFIGUPDATE=true
 
+# Public URL used to access Xen Orchestra through a domain name or reverse proxy.
+#PUBLIC_URL=""
+
+# Trust X-Forwarded-* headers sent by a reverse proxy.
+# Enable only if xo-server is not directly reachable by untrusted clients.
+# options: true/false
+#USE_FORWARDED_HEADERS="false"
+
+# Set the Secure attribute on XO session cookies.
+# Enable when HTTPS is terminated by a reverse proxy.
+# options: true/false
+#COOKIE_SECURE="false"
+
 # Location of Xen Orchestra repository where source code is fetched
 REPOSITORY="https://github.com/vatesfr/xen-orchestra"
 

--- a/xo-install.sh
+++ b/xo-install.sh
@@ -53,6 +53,9 @@ INSTALL_REPOS="${INSTALL_REPOS:-"true"}"
 SYSLOG_TARGET="${SYSLOG_TARGET:-""}"
 YARN_CACHE_CLEANUP="${YARN_CACHE_CLEANUP:-"false"}"
 YARN_NETWORK_TIMEOUT="${YARN_NETWORK_TIMEOUT:-"300000"}"
+PUBLIC_URL="${PUBLIC_URL:-""}"
+USE_FORWARDED_HEADERS="${USE_FORWARDED_HEADERS:-"false"}"
+COOKIE_SECURE="${COOKIE_SECURE:-"false"}"
 
 # set variables not changeable in configfile
 TIME=$(date +%Y%m%d%H%M)
@@ -842,6 +845,21 @@ function InstallXO {
             printinfo "Enabling remote syslog in xo-server configuration file"
             runcmd "sed -i \"s%#\[logs.transport.syslog\]%\[logs.transport.syslog\]%\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/sample.config.toml"
             runcmd "sed -i \"/^\[logs.transport.syslog.*/a target = '$SYSLOG_TARGET'\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/sample.config.toml"
+        fi
+
+        if [[ -n "$PUBLIC_URL" ]]; then
+            printinfo "Setting public URL in xo-server configuration file"
+            runcmd "sed -i \"/^#publicUrl =.*/a publicUrl = '$PUBLIC_URL'\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/sample.config.toml"
+        fi
+
+        if [[ "$USE_FORWARDED_HEADERS" == "true" ]]; then
+            printinfo "Trusting forwarded headers in xo-server configuration file"
+            runcmd "sed -i \"s/#useForwardedHeaders = true/useForwardedHeaders = true/\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/sample.config.toml"
+        fi
+
+        if [[ "$COOKIE_SECURE" == "true" ]]; then
+            printinfo "Enabling secure cookies in xo-server configuration file"
+            runcmd "sed -i \"/^\[http.cookies\]/a secure = true\" $INSTALLDIR/xo-builds/xen-orchestra-$TIME/packages/xo-server/sample.config.toml"
         fi
 
         printinfo "Activating modified configuration file"


### PR DESCRIPTION
## Summary

Adds three optional `xo-install.cfg` settings for Xen Orchestra deployments behind a reverse proxy:

- `PUBLIC_URL`
- `USE_FORWARDED_HEADERS`
- `COOKIE_SECURE`

When `CONFIGUPDATE=true`, the installer writes the selected values to the generated xo-server configuration:

- `http.publicUrl`
- `http.useForwardedHeaders`
- `http.cookies.secure`

## Motivation

XO supports these settings for reverse-proxy and TLS-termination deployments. Exposing them in `xo-install.cfg` lets users retain installer-managed configuration instead of manually editing `config.toml` after updates.

The change is proxy-agnostic; it adds no Caddy, nginx, or Traefik-specific behavior.

## Security

`USE_FORWARDED_HEADERS=true` is opt-in. It must be enabled only when xo-server’s HTTP listener is not directly reachable by untrusted clients, because forwarded headers can otherwise be spoofed.

## Scope

I am aware of #265 and the preference to avoid surfacing every xo-server setting. This proposal intentionally stays limited to the three settings needed for the common reverse-proxy/TLS-termination deployment pattern.